### PR TITLE
Fixed: Using Firefox for development causes a webworker issue and minor typo.

### DIFF
--- a/src/Add.js
+++ b/src/Add.js
@@ -56,6 +56,7 @@ class Add extends React.Component{
     let state = this.state;
     if (state["currentPage"] === "blood"){
       this.setState({currentPage: "mood"});
+    }
   }
 
   handleOnCancel() {

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -100,7 +100,9 @@ function registerValidSW(swUrl, config) {
 
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl)
+  fetch(swUrl, {
+    headers: { 'Service-Worker': 'script' }
+  })
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');
@@ -128,8 +130,12 @@ function checkValidServiceWorker(swUrl, config) {
 
 export function unregister() {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
+    navigator.serviceWorker.ready
+      .then(registration => {
+        registration.unregister();
+      })
+      .catch(error => {
+        console.error(error.message);
+      });
   }
 }


### PR DESCRIPTION
The project does not start on the Firefox in development mode, so I've used serviceWorker.js from another project which has not such issue because it was generated with newer versions of packages: 
```
    "react": "^16.13.0",
    "react-dom": "^16.13.0",
    "react-scripts": "3.4.0",
```